### PR TITLE
VE-2874: Enable Haskell in Turing's polygott build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ image: ## Build Docker image with all languages
 #TURING_LANGS := nodejs csharp java python3 php
 .PHONY: turing
 turing: ## Build Docker image with all languages
-	docker build --progress=plain  -t $(IMAGE_TAG) --build-arg LANGS="nodejs,csharp,java,python3,php,kotlin,go,cpp,ruby,swift,typescript" .
+	docker build --progress=plain  -t $(IMAGE_TAG) --build-arg LANGS="nodejs,csharp,java,python3,php,kotlin,go,cpp,ruby,swift,haskell" .
 
 image-%: ## Build Docker image with single language LANG
 	docker build --progress=plain -t polygott-$(*) --build-arg LANGS=$(*) .

--- a/languages/haskell.toml
+++ b/languages/haskell.toml
@@ -4,8 +4,15 @@ extensions = [
   "hs"
 ]
 packages = [
-  "ghc"
+  "ghc",
+  "cabal-install"
 ]
+
+setup = [
+  "cabal update"
+]
+
+install_command = "cabal install --lib "
 
 [compile]
 command = [

--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -67,7 +67,7 @@ setup = [
   "pip3 install -U email-validator && echo 'Email-validator installed'",
 ]
 
-install_command = "pip install"
+install_command = "pip3 install"
 
 [run]
 command = [


### PR DESCRIPTION
This PR also removes Typescript because it is not explicitly needed atm