### PR TITLE
VE-3165: Skip package install step silently if it is not activated for a language

### DIFF
--- a/gen/run-task.ejs
+++ b/gen/run-task.ejs
@@ -54,7 +54,7 @@ install_packages() {
       format_result $install_status $OUT_FILE $ERR_FILE $TIME_FILE
       fi
     <% } else { -%>
-      echo "No install command specified for $LANGUAGE, skipping package installation."
+      :
     <% } -%>
     fi
     ;;


### PR DESCRIPTION
With the console log, if packages are sent for a language which we don't have package installation enabled for, it fails